### PR TITLE
Commit title: Fix profile screen from bug

### DIFF
--- a/lib/view/profile_screen/profile_screen.dart
+++ b/lib/view/profile_screen/profile_screen.dart
@@ -42,7 +42,7 @@ class _ProfileScreenState extends State<ProfileScreen>
     double screenHeight = MediaQuery.of(context).size.height;
 
     return StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
-      stream: _firestore.collection("users").doc(_auth.currentUser!.uid).snapshots(),
+      stream: _firestore.collection("users").doc(_auth.currentUser?.uid).snapshots(),
       builder: (BuildContext context, AsyncSnapshot<DocumentSnapshot> snapshot) {
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator(),);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -64,6 +64,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0"
+  blinking_text:
+    dependency: "direct main"
+    description:
+      name: blinking_text
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -735,6 +742,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
+  unicons:
+    dependency: "direct main"
+    description:
+      name: unicons
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   vector_math:
     dependency: transitive
     description:


### PR DESCRIPTION
What: Fix profile screen when not login it will error

Why: Because the ! annotation means that value can't be null. But currentUser will be null when not login

How: Just change ! to ? that means the value is nullable