### PR TITLE
Commit title: Re-route login/logout and add timestamp

### DIFF
--- a/lib/model/sheet.dart
+++ b/lib/model/sheet.dart
@@ -1,8 +1,10 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:uuid/uuid.dart';
 
 const uuid = Uuid();
 
 class Sheets {
+  FieldValue timestamp = FieldValue.serverTimestamp();
   String sheetName;
   String detailSheet;
   String sid = uuid.v1();
@@ -19,19 +21,21 @@ class Sheets {
   });
 
   Sheets.fromJson(Map<String, dynamic> json)
-      : sheetName = json['sheetName'],
-        detailSheet = json['detailSheet'],
-        sid = json['sid'],
-        sheetTypeFree = json['sheetType'],
-        price = json['price'],
-        authorId = json['authorId'];
+    : timestamp = json['timestamp'],
+    sheetName = json['sheetName'],
+    detailSheet = json['detailSheet'],
+    sid = json['sid'],
+    sheetTypeFree = json['sheetType'],
+    price = json['price'],
+    authorId = json['authorId'];
 
   Map<String, dynamic> toJson() => {
-        'sheetName': sheetName,
-        'detailSheet': detailSheet,
-        'sid': sid,
-        'sheetTypeFree': sheetTypeFree,
-        'price': price,
-        'uid': authorId,
-      };
+    'timestamp': timestamp,
+    'sheetName': sheetName,
+    'detailSheet': detailSheet,
+    'sid': sid,
+    'sheetTypeFree': sheetTypeFree,
+    'price': price,
+    'uid': authorId,
+  };
 }

--- a/lib/model/user.dart
+++ b/lib/model/user.dart
@@ -1,4 +1,7 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 class Users {
+  FieldValue timestamp = FieldValue.serverTimestamp();
   String username;
   String email;
   String password;
@@ -16,7 +19,8 @@ class Users {
   });
 
   Users.fromJson(Map<String, dynamic> json)
-    : username = json['username'],
+    : timestamp = json['timestamp'],
+    username = json['username'],
     email = json['email'],
     password = json['password'],
     uid = json['uid'],
@@ -25,6 +29,7 @@ class Users {
     following = json['following'];
 
   Map<String, dynamic> toJson() => {
+    'timestamp' : timestamp,
     'username': username,
     'email': email,
     'password': password,

--- a/lib/res/components/sidebar_menu.dart
+++ b/lib/res/components/sidebar_menu.dart
@@ -112,7 +112,7 @@ class _SidebarMenuState extends State<SidebarMenu> {
                       ),
                       onTap: () {
                         myAuth.logOut();
-                        // AutoRouter.of(context).push(MainScreen());
+                        AutoRouter.of(context).navigateNamed("/home/");
                       },
                     ),
                   ],

--- a/lib/view/login.dart
+++ b/lib/view/login.dart
@@ -142,8 +142,7 @@ class _LoginScreenState extends State<LoginScreen> {
                                           myAuth.loginWithEmail(myUser.email, myUser.password)
                                           .then((value) {
                                             _formKey.currentState!.reset();
-                                            // debugPrint("Login Success!");
-                                            AutoRouter.of(context).pop();
+                                            AutoRouter.of(context).navigateNamed("/home/");
                                           });
                                         } on FirebaseAuthException catch (e) {
                                           Fluttertoast.showToast(
@@ -218,8 +217,7 @@ class _LoginScreenState extends State<LoginScreen> {
                                   try {
                                   myAuth.loginWithGoogle()
                                     .then((value) {
-                                      // debugPrint("Login Success!");
-                                      AutoRouter.of(context).pop();
+                                      AutoRouter.of(context).navigateNamed("/home/");
                                     });
                                   } on FirebaseAuthException catch (e) {
                                     Fluttertoast.showToast(
@@ -238,8 +236,7 @@ class _LoginScreenState extends State<LoginScreen> {
                                   try {
                                   myAuth.loginWithFacebook()
                                     .then((value) {
-                                      // debugPrint("Login Success!");
-                                      AutoRouter.of(context).pop();
+                                      AutoRouter.of(context).navigateNamed("/home/");
                                     });
                                   } on FirebaseAuthException catch (e) {
                                     Fluttertoast.showToast(

--- a/lib/view/register.dart
+++ b/lib/view/register.dart
@@ -154,8 +154,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                         myAuth.createUserWithEmail(myUser.email, myUser.password, myUser.username)
                                         .then((value) {
                                             _formKey.currentState!.reset();
-                                            // debugPrint("Register Success");
-                                            AutoRouter.of(context).pop();
+                                            AutoRouter.of(context).navigateNamed("/home/");
                                           },
                                         );
                                       } on FirebaseAuthException catch (e) {
@@ -204,8 +203,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                 try {
                                 myAuth.loginWithGoogle()
                                   .then((value) {
-                                    // debugPrint("Register Success!");
-                                    AutoRouter.of(context).pop();
+                                    AutoRouter.of(context).navigateNamed("/home/");
                                   });
                                 } on FirebaseAuthException catch (e) {
                                   Fluttertoast.showToast(
@@ -224,8 +222,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                 try {
                                 myAuth.loginWithFacebook()
                                   .then((value) {
-                                    // debugPrint("Login Success!");
-                                    AutoRouter.of(context).pop();
+                                    AutoRouter.of(context).navigateNamed("/home/");
                                   });
                                 } on FirebaseAuthException catch (e) {
                                   Fluttertoast.showToast(

--- a/lib/view_model/create_firestore.dart
+++ b/lib/view_model/create_firestore.dart
@@ -7,9 +7,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart' as firebase_storage;
 import 'package:firebase_core/firebase_core.dart' as firebase_core;
 import 'package:firebase_storage/firebase_storage.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:image_picker/image_picker.dart';
-import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
 
 class CreateCollection {
@@ -28,6 +25,7 @@ class CreateCollection {
     final Reference storageRef = _storage.ref().child(defaultPath);
     final String url = await storageRef.getDownloadURL();
     await _firestoreDb.collection("users").doc(argUid).set({
+      'timestamp': myUser.timestamp,
       'username': argUsername.toString().trim(),
       'email': argEmail.toString().trim(),
       'uid': argUid.toString().trim(),
@@ -45,6 +43,7 @@ class CreateCollection {
       List<String>? cutName = fullName?.split(" ");
       String? firstName = cutName?[0];
       await _firestoreDb.collection("users").doc(currentuser?.uid).set({
+        'timestamp': myUser.timestamp,
         'username': firstName,
         'email': currentuser?.email,
         'uid': currentuser?.uid,
@@ -65,6 +64,7 @@ class CreateCollection {
       String? firstName = cutName?[0];
       String profileImage = userData['picture']['data']['url'];
       await _firestoreDb.collection("users").doc(currentuser?.uid).set({
+        'timestamp': myUser.timestamp,
         'username': firstName,
         'email': currentuser?.email,
         'uid': currentuser?.uid,
@@ -78,6 +78,7 @@ class CreateCollection {
   Future<void> createSheetCollection(String argSheetName, String argDetailSheet,
       bool argSheetType, int? argPrice, String argUid) async {
     await _firestoreDb.collection("sheet").doc(mySheet.sid).set({
+      'timestamp': mySheet.timestamp,
       'sheetName': argSheetName.toString().trim(),
       'detailSheet': argDetailSheet.toString().trim(),
       'sheetTypeFree': argSheetType,

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,8 +11,8 @@ import firebase_auth
 import firebase_core
 import firebase_storage
 import flutter_secure_storage_macos
-import path_provider_macos
-import shared_preferences_macos
+import path_provider_foundation
+import shared_preferences_foundation
 import sqflite
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {


### PR DESCRIPTION
What: Change routing for login and logout to be homepage and add timestamp to firestore collection

Why: Login/Logout is for UX. Timestamp is for to order by time that data is create and use to tracking when data is update

How: Use navigateNamed instead of pop, and use fieldvalue for timestamp