### PR TITLE
Commit title : ทำให้การอ่านชีทเรียกชีทจาก Storage มาอ่านจริงๆ

### DIFF
--- a/lib/data/network/pdf_api.dart
+++ b/lib/data/network/pdf_api.dart
@@ -1,9 +1,11 @@
+import 'dart:ffi';
 import 'dart:io';
 import 'package:cheat_sheet/res/components/flushbar.dart';
 import 'package:cheat_sheet/res/components/flushbar_icon.dart';
 import 'package:cheat_sheet/res/components/sheet.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart';
@@ -32,6 +34,21 @@ class PDFApi {
     }
 
     return File(result.paths.first.toString());
+  }
+
+  static Future<File> loadPDFFromFirebase(String userId, String sheetId) async {
+    final refPDF = await firebaseStorage.FirebaseStorage.instance
+        .ref()
+        .child('users')
+        .child('/' + userId)
+        .child('/sheet')
+        .child('/' + sheetId + '.pdf');
+
+    final String url = 'users/' + userId + '/sheet/' + sheetId + '.pdf';
+
+    final bytes = await refPDF.getData();
+
+    return _storeFile(url, bytes!);
   }
 
   static Future<firebaseStorage.UploadTask?> uploadToFirebase(
@@ -64,7 +81,7 @@ class PDFApi {
     return Future.value(uploadTask);
   }
 
-  static Future<File> _storeFile(String url, List<int> bytes) async {
+  static Future<File> _storeFile(String url, Uint8List bytes) async {
     final fileName = basename(url);
     final dir = await getApplicationDocumentsDirectory();
 

--- a/lib/view/create_sheet_screen/create_detail_sheet.dart
+++ b/lib/view/create_sheet_screen/create_detail_sheet.dart
@@ -7,6 +7,7 @@ import 'package:cheat_sheet/res/components/form_field.dart';
 import 'package:cheat_sheet/res/typo.dart';
 import 'package:cheat_sheet/view_model/create_firestore.dart';
 import 'package:cheat_sheet/view_model/file_passer.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:dotted_border/dotted_border.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -54,6 +55,8 @@ class _CreateDetailSheetState extends State<CreateDetailSheet> {
         MediaQuery.of(context).orientation == Orientation.landscape;
 
     File? pdfFile = Provider.of<FilePasser>(context).getFile();
+
+    String sheetId = mySheet.sid;
 
     return FutureBuilder(
         future: firebase,
@@ -289,6 +292,7 @@ class _CreateDetailSheetState extends State<CreateDetailSheet> {
                                 try {
                                   myCollection
                                       .createSheetCollection(
+                                    sheetId,
                                     mySheet.sheetName,
                                     mySheet.detailSheet,
                                     mySheet.sheetTypeFree,
@@ -306,7 +310,7 @@ class _CreateDetailSheetState extends State<CreateDetailSheet> {
                                               pdfFile,
                                               FirebaseAuth
                                                   .instance.currentUser!.uid,
-                                              mySheet.sid);
+                                              sheetId);
                                       Future.delayed(
                                           const Duration(milliseconds: 500),
                                           () {

--- a/lib/view/home_screen/detail_sheet.dart
+++ b/lib/view/home_screen/detail_sheet.dart
@@ -60,6 +60,7 @@ class _DetailSheetState extends State<DetailSheet> {
             Map<String, dynamic> data =
                 snapshot.data!.data() as Map<String, dynamic>;
             var sheet = snapshot.data?["sid"];
+            var author = snapshot.data?["authorId"];
             return Scaffold(
               body: SafeArea(
                 child: SingleChildScrollView(
@@ -332,10 +333,9 @@ class _DetailSheetState extends State<DetailSheet> {
                                       text: "อ่านชีท",
                                       size: 16,
                                       onPressed: () async {
-                                        final url =
-                                            'https://www.africau.edu/images/default/sample.pdf';
                                         final file =
-                                            await PDFApi.loadNetwork(url);
+                                            await PDFApi.loadPDFFromFirebase(
+                                                author, sheet);
                                         AutoRouter.of(context).push(
                                             ReadSheetRoute(
                                                 sheetId: widget.sheetId,

--- a/lib/view_model/create_firestore.dart
+++ b/lib/view_model/create_firestore.dart
@@ -78,15 +78,20 @@ class CreateCollection {
     }
   }
 
-  Future<void> createSheetCollection(String argSheetName, String argDetailSheet,
-      bool argSheetType, int? argPrice, String argAuthorId) async {
-    await _firestoreDb.collection("sheet").doc(mySheet.sid).set({
+  Future<void> createSheetCollection(
+      String sheetId,
+      String argSheetName,
+      String argDetailSheet,
+      bool argSheetType,
+      int? argPrice,
+      String argAuthorId) async {
+    await _firestoreDb.collection("sheet").doc(sheetId).set({
       'timestamp': mySheet.timestamp,
       'sheetName': argSheetName.toString().trim(),
       'detailSheet': argDetailSheet.toString().trim(),
       'sheetTypeFree': argSheetType,
       'price': argPrice,
-      'sid': mySheet.sid,
+      'sid': sheetId,
       'authorId': argAuthorId,
     });
   }


### PR DESCRIPTION
What :  ทำให้การอ่านชีทเรียกชีทจาก Storage มาอ่านจริงๆ พร้อมแก้ไขบัคเก่าที่เวลา generate id แล้วไม่ใช่ตัวเดียวกับใน firebase db

Why : เพื่อให้ใช้งานได้

How : ไปแก้ไข createSheetCollection นิดหน่อยให้รับไอดีจากข้างนอกมาแทนที่จะเจนข้างใน เพราะมันดึงข้อมูลไม่ได้ ละก็ได้ทำการเพิ่มฟังก์ชั่น loadPDFFromFirebase ใน PDFApi เพื่อใช้อ่านไฟล์ pdf จาก storage

Reviewvers : @Beaterxd @PT900 
merger : @Julalak-eye 