### PR TITLE
แก้เรื่องรูปปกบัค + flushbar ตอนสร้างชีทเสร็จ (Edited: แก้บัค 0 like กับหน้าคำถามให้ดีมากขึ้น)

### DIFF
--- a/lib/data/network/pdf_api.dart
+++ b/lib/data/network/pdf_api.dart
@@ -75,7 +75,7 @@ class PDFApi {
     firebaseStorage.FirebaseStorage.instance.ref().child('sheets').child(sheetId).child('cover_image.png').delete();
   }
 
-  static Future<firebaseStorage.UploadTask?> createCoverSheetImage(String sheetId) async {
+  Future<firebaseStorage.UploadTask?> createCoverSheetImage(String sheetId) async {
     final File file = await loadPDFFromFirebase(sheetId);
 
     imglib.Image coverImage = await _getImageFromPdf(file, 1);
@@ -102,27 +102,39 @@ class PDFApi {
     return file;
   }
 
-  static Future<File> _imageToFile(imglib.Image inputImage) async {
+  Future<File> _imageToFile(imglib.Image inputImage) async {
     final dir = await getExternalStorageDirectory();
 
     File imageFile = File('${dir!.path}/image.png');
     await Future.wait([
       File(imageFile.path).writeAsBytes(imglib.encodePng(inputImage)),
     ]);
-    int fileSize = await imageFile.length();
-    debugPrint("Before loop file size: $fileSize");
+
+    return coverImageCorruptHandler(inputImage, imageFile);
+  }
+
+  Future<File> coverImageCorruptHandler(imglib.Image newImage, File handler) async {
+    int handlerSize = await handler.length();
+    if (handlerSize != 0) {
+      debugPrint("Image size is: $handlerSize, and it's not corrupt.");
+      return handler;
+    }
     int i = 1;
-    while (fileSize == 0) {
-      if (fileSize != 0) break;
+    while (handlerSize == 0) {
+      if (i == 1) debugPrint("Begin fixing...");
+      if (handlerSize != 0) {
+        debugPrint("Fixing ends with $handlerSize image file size.");
+        break;
+      }
       await Future.wait([
-        File(imageFile.path).writeAsBytes(imglib.encodePng(inputImage)),
+        File(handler.path).writeAsBytes(imglib.encodePng(newImage)),
       ]);
-      fileSize = await imageFile.length();
-      debugPrint("Round $i Filesize: $fileSize");
+      handlerSize = await handler.length();
+      debugPrint("Round $i fixed, new image size is: $handlerSize");
       i++;
     }
 
-    return imageFile;
+    return handler;
   }
 
   static Future<imglib.Image> _getImageFromPdf(File inputFile, int pageNumber) async {

--- a/lib/view/create_sheet_screen/create_detail_sheet.dart
+++ b/lib/view/create_sheet_screen/create_detail_sheet.dart
@@ -228,7 +228,7 @@ class _CreateDetailSheetState extends State<CreateDetailSheet> {
                               _formKey.currentState!.save();
                               firebaseStorage.UploadTask? task = await PDFApi.uploadToFirebase(context, pdfFile, sheetId);
                               task!.whenComplete(() async {
-                                firebaseStorage.UploadTask? coverImage = await PDFApi.createCoverSheetImage(sheetId);
+                                firebaseStorage.UploadTask? coverImage = await PDFApi().createCoverSheetImage(sheetId);
                                 coverImage!.whenComplete(() async {
                                   String coverImage = await PDFApi.getCoverImage(sheetId);
                                   try {

--- a/lib/view/home_screen/question/ask_question.dart
+++ b/lib/view/home_screen/question/ask_question.dart
@@ -92,14 +92,16 @@ class _AskQuestionState extends State<AskQuestion> {
                           .snapshots(),
                       builder: (context, snapshot) {
                         if (!snapshot.hasData) {
-                          return Center(child: CircularProgressIndicator());
+                          return Container();
+                        } else if (snapshot.connectionState == ConnectionState.waiting) {
+                          return const Center(child: CircularProgressIndicator());
                         }
                         int questionCount = snapshot.data!.docs.length;
                         if (questionCount == 0) {
                           return SizedBox(
                             height: screenWidth * 0.57,
                             child: const Center(
-                              child: Regular16px(text: "ยังไม่มีรีวิว"),
+                              child: Regular16px(text: "ยังไม่มีคำถาม"),
                             ),
                           );
                         }
@@ -112,8 +114,10 @@ class _AskQuestionState extends State<AskQuestion> {
                             return FutureBuilder(
                                 future: _firestore.collection('users').doc(question['questionerId']).get(),
                                 builder: (context, userSnapshot) {
-                                  if (!snapshot.hasData) {
-                                    return Center(child: CircularProgressIndicator());
+                                  if (!userSnapshot.hasData) {
+                                    return Container();
+                                  } else if (userSnapshot.connectionState == ConnectionState.waiting) {
+                                    return const Center(child: CircularProgressIndicator());
                                   }
                                   Map<String, dynamic>? user = userSnapshot.data?.data();
                                   return InkWell(

--- a/lib/view/home_screen/question/create_question.dart
+++ b/lib/view/home_screen/question/create_question.dart
@@ -134,7 +134,7 @@ class _CreateQuestionState extends State<CreateQuestion> {
                         PictureDetails image = _controller.finish();
                         _formKey.currentState!.save();
                         try {
-                          firebaseStorage.UploadTask? task = await ImageApi.uploadToFirebase(image, questionId);
+                          firebaseStorage.UploadTask? task = await ImageApi().uploadToFirebase(image, questionId);
                           task!.whenComplete(() {
                             myCollection
                                 .createQuestionCollection(

--- a/lib/view_model/create_firestore.dart
+++ b/lib/view_model/create_firestore.dart
@@ -30,7 +30,7 @@ class CreateCollection {
   Sheets mySheet = Sheets(sheetName: '', detailSheet: '', sheetCoverImage: '', demoPages: [], sheetTypeFree: true, authorId: '');
   SheetLists mySheetLists = SheetLists(sheetListName: '', sid: [], authorId: '', sheetListId: '');
   Reviews myReview = Reviews(text: '', rid: '', reviewerId: '', sheetId: '', rating: 0, like: 0);
-  Question myQuestion = Question(text: '', sheetId: '', questionerId: '', askingPage: 0);
+  Question myQuestion = Question(text: '', sheetId: '', questionerId: '', askingPage: 0, like: 0, dislike: 0);
 
   Future<void> createUserCollection(String argUsername, String argEmail, String argUid) async {
     const String defaultPath = "images/default_profile.png";


### PR DESCRIPTION
_Noted: เพราะว่ามันไม่เจอบัคซักทีหลังทดลองอัพชีทมาเกิน 30 ชีท เลยถือว่าแก้ได้แล้ว แต่ถ้าหลัง merged ไปหรือมีใคร pull ไปลองแล้วยังบัคอยู่ให้รีบบอกเลยนะ และหลัง commit รอบสองก็ขึ้เกียจอัพชีทแล้วเพราะไม่เจอบัคซักที ก็ขอยาดเลยละกัน_

### Edited: แก้บัคอื่นๆ คือ
1. like กับ dislike ที่เป็น 0 เวลาสร้างคำถาม แก้โดยการ assign ค่าให้มันซะ ตอนที่ประกาศ Question ตอนต้นไฟล์
2. แก้หน้าคำถามให้สามารถใช้ ConnectionState.waiting ได้ ก่อนหน้านี้ที่มันใช้ไม่ได้เพราะมันเช็ค snapshot ผิดตัวทำให้มันทำงานประหลาด หลังแก้มันก็ใช้ได้ปกติดี
3. แก้ image_api ไฟล์ให้ทำเหมือนกับ pdf_api ไฟล์ ที่มีการ handle เวลาแปลงไฟล์ เพื่อป้องกันรูปพัง ถ้าถามว่าทำไม method ที่ทำงานเหมือนกันเกือบ 100% ถึงต้องแยกกัน เป็นเพราะว่าภายใน writeAsBytes มันรับ input คนละตัวกัน และเรารับ input มาจาก arguments ทำให้มันต้องแก้ argument เพื่อรับคนละอย่างกัน พอแล้วอ่านเองละกัน😏

What: หลักๆแล้วคือการแก้บัคที่รูปปกหายไปทำให้มันแสดงผลผิดพลาด กับอีกส่วนคือแก้ flushbar icon ตอนที่สร้างชีทเสร็จ เพราะอะไรไม่รู้มันถึงเป็นแบบ error เลยแก้ให้เป็น successIcon แทน

Why: ก็หวังว่าจะช่วยให้ไม่มีบัครูปปกชีทอีก กับสามารถแสดงผล flushbar ได้ถูกต้องมากขึ้น

How: ก่อนที่จะเริ่มทำงานได้ลองอัพชีทไปอันนึงแล้วมันบัคให้พอดี ก็ลองไปเปิดเช็คดู พบว่ามันเป็น file ขนาด 0 byte ทำให้ลองใช้วิธีแบบนี้ ขั้นแรกคือเช็คจำนวน bytes ของ file ที่แปลงมาแล้วก่อน ถ้าไฟล์มี byte เป็น 0 ก็เข้า while loop ไปแปลงไฟล์ใหม่เรื่อยๆ จนกว่า bytes จะไม่เป็น 0 ถึงจะออกจาก loop แต่ต้องบอกก่อนว่ามันไม่เคยเข้า loop เลยเพราะมันไม่บัคให้ซะที หลังจากนี้ก็เวลาอัพชีทก็ลองดู console ให้ด้วยว่ามัน print อะไรออกมาบ้าง จะได้เช็คได้ว่ามันทำงานได้ถูกต้อง

Reviewers: @ArtMuchimuchi @Beaterxd 
Assignees: @Bookkub 